### PR TITLE
[PLANO-8] PlanoProcessor and REST API implementation

### DIFF
--- a/src/main/java/org/plano/PlanoController.java
+++ b/src/main/java/org/plano/PlanoController.java
@@ -1,10 +1,8 @@
 package org.plano;
 
-/**
- * Created by ctsai on 11/5/16.
- */
-
+import org.plano.data.PlanoRequest;
 import org.plano.data.PlanoResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,41 +10,110 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * {@link PlanoController} maps HTTP requests to corresponding handlers.
+ */
 @RestController
 public class PlanoController {
+    private PlanoProcessor planoProcessor;
 
+    /**
+     * GET method to retrieve {@link PlanoRequest} with RequestID.
+     * @param requestID RequestID.
+     * @return {@link ResponseEntity}.
+     */
     @GetMapping(path = "/requests/{requestID}",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity getRequest(@PathVariable String requestID,
-            @RequestHeader String transactionGUID) {
-        return null;
+    public ResponseEntity getRequest(@PathVariable String requestID) {
+        PlanoResponse planoResponse = planoProcessor.getRequest(requestID);
+        ResponseEntity<PlanoResponse> responseEntity = composeResponseEntity(planoResponse);
+
+        return responseEntity;
     }
 
+    /**
+     * POST method to save {@link PlanoRequest} to persistence data store.
+     * @param planoRequest {@link PlanoRequest}.
+     * @return {@link ResponseEntity}.
+     */
     @PostMapping(path = "/requests",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity addRequest() {
-        return null;
+    public ResponseEntity addRequest(@RequestBody PlanoRequest planoRequest) {
+        PlanoResponse planoResponse = planoProcessor.addRequest(planoRequest);
+        ResponseEntity<PlanoResponse> responseEntity = composeResponseEntity(planoResponse);
+
+        return responseEntity;
     }
 
+    /**
+     * PUT method to update {@link PlanoRequest} to persistence data store.
+     * @param requestID RequestID.
+     * @param planoRequest {@link PlanoRequest}.
+     * @return {@link ResponseEntity}.
+     */
     @PutMapping(path = "/requests/{requestID}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity updateRequest(@PathVariable String requestID) {
-        return null;
+    public ResponseEntity updateRequest(@PathVariable String requestID, @RequestBody PlanoRequest planoRequest) {
+        PlanoResponse planoResponse = planoProcessor.updateRequest(requestID, planoRequest);
+        ResponseEntity<PlanoResponse> responseEntity = composeResponseEntity(planoResponse);
+
+        return responseEntity;
     }
 
+    /**
+     * DELETE method to remove {@link PlanoRequest} from persistence data store with RequestID.
+     * @param requestID RequestID.
+     * @return {@link ResponseEntity}.
+     */
     @DeleteMapping(path = "/requests/{requestID}",
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity removeRequest(@PathVariable String requestID) {
-        return null;
+        PlanoResponse planoResponse = planoProcessor.removeRequest(requestID);
+        ResponseEntity<PlanoResponse> responseEntity = composeResponseEntity(planoResponse);
+
+        return responseEntity;
     }
 
+    /**
+     * GET method to return system health.
+     * @return {@link ResponseEntity}.
+     */
     @GetMapping(path = "/health", produces = MediaType.TEXT_PLAIN_VALUE)
     public ResponseEntity health() {
         return ResponseEntity.ok().body("healthy");
+    }
+
+    public void setPlanoProcessor(PlanoProcessor planoProcessor) {
+        this.planoProcessor = planoProcessor;
+    }
+
+    /**
+     * Compose {@link ResponseEntity} based on {@link PlanoResponse}.
+     * @param planoResponse {@link PlanoResponse}.
+     * @return {@link ResponseEntity}.
+     */
+    private ResponseEntity<PlanoResponse> composeResponseEntity(PlanoResponse planoResponse) {
+        ResponseEntity<PlanoResponse> responseEntity = null;
+        switch (planoResponse.getPlanoStatus()) {
+            case SUCCESS:
+                responseEntity = new ResponseEntity<>(planoResponse, HttpStatus.OK);
+                break;
+            case CREATED:
+                responseEntity = new ResponseEntity<>(planoResponse, HttpStatus.CREATED);
+                break;
+            case NOT_FOUND:
+                responseEntity = new ResponseEntity<>(planoResponse, HttpStatus.NOT_FOUND);
+                break;
+            case INVALID_INPUT:
+                responseEntity = new ResponseEntity<>(planoResponse, HttpStatus.BAD_REQUEST);
+                break;
+        }
+
+        return responseEntity;
     }
 }

--- a/src/main/java/org/plano/PlanoProcessor.java
+++ b/src/main/java/org/plano/PlanoProcessor.java
@@ -1,0 +1,119 @@
+package org.plano;
+
+import org.plano.data.PlanoRequest;
+import org.plano.data.PlanoResponse;
+import org.plano.data.PlanoStatus;
+import org.plano.exception.InvalidRequestException;
+import org.plano.exception.ResourceNotFoundException;
+import org.plano.repository.Repository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link PlanoProcessor} is responsible to validate the request, call {@link Repository}
+ * and compose the {@link PlanoResponse}.
+ */
+@Component
+public class PlanoProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(PlanoProcessor.class);
+
+    private Repository<PlanoRequest> repositoryWrapper;
+
+    /**
+     * Get {@link PlanoRequest} from {@link Repository}.
+     * @param requestID RequestID.
+     * @return {@link PlanoResponse}.
+     */
+    public PlanoResponse getRequest(String requestID) {
+        PlanoResponse planoResponse = new PlanoResponse();
+        try {
+            PlanoRequest planoRequest = repositoryWrapper.getRequest(requestID);
+
+            planoResponse.setPlanoRequest(planoRequest);
+            planoResponse.setPlanoStatus(PlanoStatus.SUCCESS);
+        } catch (ResourceNotFoundException e) {
+            planoResponse.setPlanoStatus(PlanoStatus.NOT_FOUND);
+            planoResponse.setErrorMessage(e.getMessage());
+        }
+
+        return planoResponse;
+    }
+
+    /**
+     * Add {@link PlanoRequest} to {@link Repository}.
+     * @param planoRequest {@link PlanoRequest}.
+     * @return {@link PlanoResponse}.
+     */
+    public PlanoResponse addRequest(PlanoRequest planoRequest) {
+        PlanoResponse planoResponse = new PlanoResponse();
+        try {
+            if (!planoRequest.isValid()) {
+                String message = String.format("Invalid PlanoRequest: {}", planoRequest);
+                throw new InvalidRequestException(message);
+            }
+
+            String requestID = repositoryWrapper.addRequest(planoRequest);
+
+            planoResponse.setRequestID(requestID);
+            planoResponse.setPlanoStatus(PlanoStatus.CREATED);
+        } catch (InvalidRequestException e) {
+            planoResponse.setPlanoStatus(PlanoStatus.INVALID_INPUT);
+            planoResponse.setErrorMessage(e.getMessage());
+        }
+
+        return planoResponse;
+    }
+
+    /**
+     * Update {@link PlanoRequest} in {@link Repository}.
+     * @param requestID RequestID.
+     * @param planoRequest {@link PlanoRequest}.
+     * @return {@link PlanoResponse}.
+     */
+    public PlanoResponse updateRequest(String requestID, PlanoRequest planoRequest) {
+        PlanoResponse planoResponse = new PlanoResponse();
+        try {
+            if (!planoRequest.isValid()) {
+                String message = String.format("Invalid PlanoRequest: {}", planoRequest);
+                throw new InvalidRequestException(message);
+            }
+
+            planoRequest.setRequestID(requestID);
+
+            repositoryWrapper.updateRequest(planoRequest);
+
+            planoResponse.setRequestID(requestID);
+            planoResponse.setPlanoStatus(PlanoStatus.SUCCESS);
+        } catch (InvalidRequestException e) {
+            planoResponse.setPlanoStatus(PlanoStatus.INVALID_INPUT);
+            planoResponse.setErrorMessage(e.getMessage());
+        }
+
+        return planoResponse;
+    }
+
+    /**
+     * Removes {@link PlanoRequest} from {@link Repository} with RequestID.
+     * @param requestID RequestID.
+     * @return {@link PlanoResponse}.
+     */
+    public PlanoResponse removeRequest(String requestID) {
+        PlanoResponse planoResponse = new PlanoResponse();
+        try {
+            repositoryWrapper.removeRequest(requestID);
+
+            planoResponse.setRequestID(requestID);
+            planoResponse.setPlanoStatus(PlanoStatus.SUCCESS);
+        } catch (InvalidRequestException e) {
+            planoResponse.setPlanoStatus(PlanoStatus.INVALID_INPUT);
+            planoResponse.setErrorMessage(e.getMessage());
+        }
+
+        return planoResponse;
+    }
+
+    public void setRepositoryWrapper(Repository<PlanoRequest> repositoryWrapper) {
+        this.repositoryWrapper = repositoryWrapper;
+    }
+}

--- a/src/main/java/org/plano/data/PlanoRequest.java
+++ b/src/main/java/org/plano/data/PlanoRequest.java
@@ -41,17 +41,18 @@ public class PlanoRequest {
         executionTime = new Date(System.currentTimeMillis() + executionIntervalMs);
     }
 
-    public boolean isValid() throws IllegalAccessException {
+    public boolean isValid() {
         final Field[] fields = this.getClass().getDeclaredFields();
-
-        for (Field field : fields)
-        {
-            if (field.isAnnotationPresent(NotNull.class) && field.get(this) == null)
-            {
-                return false;
+        try {
+            for (Field field : fields) {
+                if (field.isAnnotationPresent(NotNull.class) && field.get(this) == null) {
+                    return false;
+                }
             }
+        } catch (IllegalAccessException e) {
+            String message = String.format("Failed when validating PlanoRequest: {0}", this);
+            LOG.error(message, e.getCause());
         }
-
         return true;
     }
 

--- a/src/main/java/org/plano/data/PlanoResponse.java
+++ b/src/main/java/org/plano/data/PlanoResponse.java
@@ -1,17 +1,47 @@
 package org.plano.data;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * PlanoResponse POJO.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PlanoResponse {
-    String href = "HREF";
+    private PlanoRequest planoRequest;
+    private String errorMessage;
+    private String requestID;
+    private PlanoStatus planoStatus;
 
-    public void setHref(final String href) {
-        this.href = href;
+    public PlanoRequest getPlanoRequest() {
+        return planoRequest;
     }
 
-    public String getHref() {
-        return this.href;
+    public void setPlanoRequest(PlanoRequest planoRequest) {
+        this.planoRequest = planoRequest;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getRequestID() {
+        return requestID;
+    }
+
+    public void setRequestID(String requestID) {
+        this.requestID = requestID;
+    }
+
+    public PlanoStatus getPlanoStatus() {
+        return planoStatus;
+    }
+
+    public void setPlanoStatus(PlanoStatus planoStatus) {
+        this.planoStatus = planoStatus;
     }
 }

--- a/src/main/java/org/plano/data/PlanoStatus.java
+++ b/src/main/java/org/plano/data/PlanoStatus.java
@@ -1,0 +1,21 @@
+package org.plano.data;
+
+/**
+ * Created by ctsai on 12/13/16.
+ */
+public enum PlanoStatus {
+    SUCCESS("Success"),
+    CREATED("Created"),
+    NOT_FOUND("Resource not Found"),
+    INVALID_INPUT("Invalid input");
+
+    private final String value;
+
+    PlanoStatus(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/org/plano/master/PlanoMaster.java
+++ b/src/main/java/org/plano/master/PlanoMaster.java
@@ -36,7 +36,7 @@ public class PlanoMaster implements Master {
     private Long schedulePeriodMs;
 
     @PostConstruct
-    void init() {
+    public void init() {
         scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(threadPoolSize);
     }
 

--- a/src/test/java/functional/PlanoApplicationTests.java
+++ b/src/test/java/functional/PlanoApplicationTests.java
@@ -1,12 +1,13 @@
-package org.plano;
+package functional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.plano.PlanoApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = PlanoApplication.class)
 public class PlanoApplicationTests {
 
 	@Test

--- a/src/test/java/unit/PlanoControllerTests.java
+++ b/src/test/java/unit/PlanoControllerTests.java
@@ -1,0 +1,144 @@
+package unit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.plano.PlanoController;
+import org.plano.PlanoProcessor;
+import org.plano.data.PlanoRequest;
+import org.plano.data.PlanoResponse;
+import org.plano.data.PlanoStatus;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.AssertionErrors;
+
+public class PlanoControllerTests {
+
+	@Mock
+	PlanoProcessor mockedPlanoProcessor;
+
+	PlanoController planoController;
+
+	@Before
+	public void before() {
+		MockitoAnnotations.initMocks(this);
+		planoController = new PlanoController();
+		planoController.setPlanoProcessor(mockedPlanoProcessor);
+	}
+
+	@Test
+	public void testGetRequestSuccess() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.SUCCESS);
+
+		Mockito.when(mockedPlanoProcessor.getRequest(Mockito.anyString()))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.getRequest(Mockito.anyString());
+
+		Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void testGetRequestNotFound() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.NOT_FOUND);
+
+		Mockito.when(mockedPlanoProcessor.getRequest(Mockito.anyString()))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.getRequest(Mockito.anyString());
+
+		Assert.assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void testAddRequestSuccess() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.CREATED);
+
+		Mockito.when(mockedPlanoProcessor.addRequest(Mockito.any(PlanoRequest.class)))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.addRequest(Mockito.any(PlanoRequest.class));
+
+		Assert.assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void testAddRequestInvalidInput() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.INVALID_INPUT);
+
+		Mockito.when(mockedPlanoProcessor.addRequest(Mockito.any(PlanoRequest.class)))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.addRequest(Mockito.any(PlanoRequest.class));
+
+		Assert.assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void testUpdateRequestSuccess() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.SUCCESS);
+
+		Mockito.when(mockedPlanoProcessor.updateRequest(Mockito.anyString(), Mockito.any(PlanoRequest.class)))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.updateRequest(Mockito.anyString(), Mockito.any(PlanoRequest.class));
+
+		Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void testUpdateRequestInvalidInput() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.INVALID_INPUT);
+
+		Mockito.when(mockedPlanoProcessor.updateRequest(Mockito.anyString(), Mockito.any(PlanoRequest.class)))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.updateRequest(Mockito.anyString(), Mockito.any(PlanoRequest.class));
+
+		Assert.assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void testRemoveRequestSuccess() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.SUCCESS);
+
+		Mockito.when(mockedPlanoProcessor.removeRequest(Mockito.anyString()))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.removeRequest(Mockito.anyString());
+
+		Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void testRemoveRequestInvalidInput() {
+		PlanoResponse planoResponse = new PlanoResponse();
+		planoResponse.setPlanoStatus(PlanoStatus.INVALID_INPUT);
+
+		Mockito.when(mockedPlanoProcessor.removeRequest(Mockito.anyString()))
+				.thenReturn(planoResponse);
+
+		ResponseEntity<PlanoResponse> responseEntity =  planoController.removeRequest(Mockito.anyString());
+
+		Assert.assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+	}
+
+	@After
+	public void after() {
+		Mockito.reset(mockedPlanoProcessor);
+	}
+}

--- a/src/test/java/unit/PlanoProcessorTests.java
+++ b/src/test/java/unit/PlanoProcessorTests.java
@@ -1,0 +1,129 @@
+package unit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.plano.PlanoProcessor;
+import org.plano.data.PlanoRequest;
+import org.plano.data.PlanoResponse;
+import org.plano.data.PlanoStatus;
+import org.plano.exception.InvalidRequestException;
+import org.plano.exception.ResourceNotFoundException;
+import org.plano.repository.Repository;
+import utils.DataTestUtils;
+
+public class PlanoProcessorTests {
+    @Mock
+    private Repository<PlanoRequest> mockedRepositoryWrapper;
+    private PlanoProcessor planoProcessor;
+    private static final String REQUEST_ID = "43c8e50c-2e5b-4e36-a3d6-4e144f6c6d5d";
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        planoProcessor = new PlanoProcessor();
+        planoProcessor.setRepositoryWrapper(mockedRepositoryWrapper);
+    }
+
+    @Test
+    public void testGetRequestSuccess() throws ResourceNotFoundException {
+        PlanoRequest planoRequest = DataTestUtils.createPlanoRequest();
+
+        Mockito.when(mockedRepositoryWrapper.getRequest(REQUEST_ID))
+                .thenReturn(planoRequest);
+
+        PlanoResponse planoResponse = planoProcessor.getRequest(REQUEST_ID);
+
+        Assert.assertEquals(PlanoStatus.SUCCESS, planoResponse.getPlanoStatus());
+        Assert.assertEquals(planoRequest, planoResponse.getPlanoRequest());
+    }
+
+    @Test
+    public void testGetRequestNotFound() throws ResourceNotFoundException {
+        Mockito.when(mockedRepositoryWrapper.getRequest(Mockito.anyString()))
+                .thenThrow(new ResourceNotFoundException("Resource not found."));
+
+        PlanoResponse planoResponse = planoProcessor.getRequest(REQUEST_ID);
+
+        Assert.assertEquals(PlanoStatus.NOT_FOUND, planoResponse.getPlanoStatus());
+        Assert.assertNotNull(planoResponse.getErrorMessage());
+    }
+
+    @Test
+    public void testAddRequestCreated() throws InvalidRequestException {
+        PlanoRequest mockedPlanoRequest = Mockito.mock(PlanoRequest.class);
+
+        Mockito.when(mockedPlanoRequest.isValid()).thenReturn(true);
+
+        Mockito.when(mockedRepositoryWrapper.addRequest(mockedPlanoRequest))
+                .thenReturn(REQUEST_ID);
+
+        PlanoResponse planoResponse = planoProcessor.addRequest(mockedPlanoRequest);
+
+        Assert.assertEquals(PlanoStatus.CREATED, planoResponse.getPlanoStatus());
+        Assert.assertEquals(REQUEST_ID, planoResponse.getRequestID());
+    }
+
+    @Test
+    public void testAddRequestInvalidInput() {
+        PlanoRequest mockedPlanoRequest = Mockito.mock(PlanoRequest.class);
+
+        Mockito.when(mockedPlanoRequest.isValid()).thenReturn(false);
+
+        PlanoResponse planoResponse = planoProcessor.addRequest(mockedPlanoRequest);
+
+        Assert.assertEquals(PlanoStatus.INVALID_INPUT, planoResponse.getPlanoStatus());
+        Assert.assertNotNull(planoResponse.getErrorMessage());
+    }
+
+    @Test
+    public void testUpdateRequestSuccess() {
+        PlanoRequest mockedPlanoRequest = Mockito.mock(PlanoRequest.class);
+
+        Mockito.when(mockedPlanoRequest.isValid()).thenReturn(true);
+
+        PlanoResponse planoResponse = planoProcessor.updateRequest(REQUEST_ID, mockedPlanoRequest);
+
+        Assert.assertEquals(PlanoStatus.SUCCESS, planoResponse.getPlanoStatus());
+        Assert.assertEquals(REQUEST_ID, planoResponse.getRequestID());
+    }
+
+    @Test
+    public void testUpdateRequestInvalidInput() {
+        PlanoRequest mockedPlanoRequest = Mockito.mock(PlanoRequest.class);
+
+        Mockito.when(mockedPlanoRequest.isValid()).thenReturn(false);
+
+        PlanoResponse planoResponse = planoProcessor.updateRequest(REQUEST_ID, mockedPlanoRequest);
+
+        Assert.assertEquals(PlanoStatus.INVALID_INPUT, planoResponse.getPlanoStatus());
+        Assert.assertNotNull(planoResponse.getErrorMessage());
+    }
+
+    @Test
+    public void testRemoveRequestSuccess() {
+        PlanoResponse planoResponse = planoProcessor.removeRequest(REQUEST_ID);
+
+        Assert.assertEquals(PlanoStatus.SUCCESS, planoResponse.getPlanoStatus());
+        Assert.assertEquals(REQUEST_ID, planoResponse.getRequestID());
+    }
+
+    @Test
+    public void testRemoveRequestInvalidInput() throws InvalidRequestException {
+        Mockito.doThrow(new InvalidRequestException("Invalid request."))
+                .when(mockedRepositoryWrapper).removeRequest(REQUEST_ID);
+
+        PlanoResponse planoResponse = planoProcessor.removeRequest(REQUEST_ID);
+
+        Assert.assertEquals(PlanoStatus.INVALID_INPUT, planoResponse.getPlanoStatus());
+    }
+
+    @After
+    public void after() {
+        Mockito.reset(mockedRepositoryWrapper);
+    }
+}

--- a/src/test/java/unit/master/PlanoMasterTests.java
+++ b/src/test/java/unit/master/PlanoMasterTests.java
@@ -1,9 +1,10 @@
-package org.plano.master;
+package unit.master;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.plano.master.PlanoMaster;
 import org.plano.worker.PlanoWorker;
 
 public class PlanoMasterTests {

--- a/src/test/java/unit/repository/RepositoryFactoryTests.java
+++ b/src/test/java/unit/repository/RepositoryFactoryTests.java
@@ -1,7 +1,10 @@
-package org.plano.repository;
+package unit.repository;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.plano.repository.Repository;
+import org.plano.repository.RepositoryFactory;
+import org.plano.repository.RepositoryType;
 import org.plano.repository.dynamodb.DynamoDBRepository;
 
 public class RepositoryFactoryTests {

--- a/src/test/java/unit/repository/dynamodb/DynamoDBRepositoryTests.java
+++ b/src/test/java/unit/repository/dynamodb/DynamoDBRepositoryTests.java
@@ -1,14 +1,23 @@
-package org.plano.repository.dynamodb;
+package unit.repository.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
-import com.amazonaws.services.dynamodbv2.model.*;
-import org.junit.*;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.CreateTableResult;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableResult;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.plano.data.PlanoRequest;
 import org.plano.exception.InvalidRequestException;
 import org.plano.exception.PlanoException;
 import org.plano.exception.ResourceNotFoundException;
+import org.plano.repository.dynamodb.DynamoDBRepository;
 import org.plano.repository.dynamodb.model.DynamoDBPlanoRequest;
 import utils.DataTestUtils;
 

--- a/src/test/java/unit/repository/dynamodb/DynamoDBUtilsTests.java
+++ b/src/test/java/unit/repository/dynamodb/DynamoDBUtilsTests.java
@@ -1,8 +1,9 @@
-package org.plano.repository.dynamodb;
+package unit.repository.dynamodb;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.plano.data.PlanoRequest;
+import org.plano.repository.dynamodb.DynamoDBUtils;
 import org.plano.repository.dynamodb.model.DynamoDBPlanoRequest;
 import utils.DynamoDBTestUtils;
 

--- a/src/test/java/unit/repository/dynamodb/model/DynamoDBPlanoRequestTests.java
+++ b/src/test/java/unit/repository/dynamodb/model/DynamoDBPlanoRequestTests.java
@@ -1,10 +1,13 @@
-package org.plano.repository.dynamodb.model;
+package unit.repository.dynamodb.model;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.plano.data.HttpRequest;
 import org.plano.data.PlanoRequest;
 import org.plano.data.SchedulePolicy;
+import org.plano.repository.dynamodb.model.DynamoDBHttpRequest;
+import org.plano.repository.dynamodb.model.DynamoDBPlanoRequest;
+import org.plano.repository.dynamodb.model.DynamoDBSchedulePolicy;
 
 /**
  * Created by ctsai on 11/28/16.

--- a/src/test/java/unit/worker/HttpEndpointInvokerTests.java
+++ b/src/test/java/unit/worker/HttpEndpointInvokerTests.java
@@ -1,4 +1,4 @@
-package org.plano.worker;
+package unit.worker;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
@@ -6,8 +6,11 @@ import org.apache.http.HttpStatus;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.*;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
@@ -18,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.plano.data.HttpRequest;
+import org.plano.worker.HttpEndpointInvoker;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/unit/worker/PlanoWorkerTests.java
+++ b/src/test/java/unit/worker/PlanoWorkerTests.java
@@ -1,4 +1,4 @@
-package org.plano.worker;
+package unit.worker;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -9,6 +9,8 @@ import org.plano.data.HttpRequest;
 import org.plano.data.PlanoRequest;
 import org.plano.exception.InvalidRequestException;
 import org.plano.repository.Repository;
+import org.plano.worker.EndpointInvoker;
+import org.plano.worker.PlanoWorker;
 
 public class PlanoWorkerTests {
     @Mock


### PR DESCRIPTION
## Scope
Clients invoke Plano with requests. We need to validate their requests before saving to database. PlanoProcessor is responsible for validating requests and persist the request to repository. PlanoProcessor is also responsible for composing the response.